### PR TITLE
stop fuzzy matching if only number are passed in to the find_fuzzy_matches function

### DIFF
--- a/lib/peach.ex
+++ b/lib/peach.ex
@@ -106,21 +106,27 @@ defmodule Peach do
   def find_fuzzy_matches(input, keyword_threshold_set) do
     cleaned_input = remove_numbers(input)
 
-    keyword_threshold_set
-    # add the edit distance.
-    |> Enum.map(fn {keyword, threshold} ->
-      {keyword, levenshtein_distance(cleaned_input, keyword), threshold}
-    end)
-    # only keep close matches.
-    |> Enum.filter(fn {_keyword, distance, threshold} ->
-      distance <= threshold
-    end)
-    # drop threshold.
-    |> Enum.map(fn {keyword, distance, _threshold} ->
-      {keyword, distance}
-    end)
-    # order from best to worst matches.
-    |> Enum.sort(&(elem(&1, 1) < elem(&2, 1)))
+    case cleaned_input do
+      "" ->
+        []
+
+      _ ->
+        keyword_threshold_set
+        # add the edit distance.
+        |> Enum.map(fn {keyword, threshold} ->
+          {keyword, levenshtein_distance(cleaned_input, keyword), threshold}
+        end)
+        # only keep close matches.
+        |> Enum.filter(fn {_keyword, distance, threshold} ->
+          distance <= threshold
+        end)
+        # drop threshold.
+        |> Enum.map(fn {keyword, distance, _threshold} ->
+          {keyword, distance}
+        end)
+        # order from best to worst matches.
+        |> Enum.sort(&(elem(&1, 1) < elem(&2, 1)))
+    end
   end
 
   @doc """

--- a/test/peach_test.exs
+++ b/test/peach_test.exs
@@ -344,5 +344,32 @@ defmodule PeachTest do
       |> Peach.find_fuzzy_matches(keyword_threshold_set)
 
     assert matches == [{"optin", 1}, {"optout", 2}]
+
+    input = "202001"
+    keyword_threshold_set = MapSet.new([{"hi", 2}, {"aa", 2}, {"bb", 2}, {"foo", 2}])
+
+    matches =
+      Peach.pre_process(input)
+      |> Peach.find_fuzzy_matches(keyword_threshold_set)
+
+    assert matches == []
+
+    input = "202a001"
+    keyword_threshold_set = MapSet.new([{"hi", 2}])
+
+    matches =
+      Peach.pre_process(input)
+      |> Peach.find_fuzzy_matches(keyword_threshold_set)
+
+    assert matches == []
+
+    input = "202aa001"
+    keyword_threshold_set = MapSet.new([{"hi", 2}])
+
+    matches =
+      Peach.pre_process(input)
+      |> Peach.find_fuzzy_matches(keyword_threshold_set)
+
+    assert matches == []
   end
 end


### PR DESCRIPTION
if you have a input string that was made up completely of digits like "21002" and a keyword like "hi", then `find_fuzzy_matches` would result in matching `""` with keywords that were 1-2 characters long.